### PR TITLE
New AdsPostParser logic

### DIFF
--- a/src/AdsPostParser.php
+++ b/src/AdsPostParser.php
@@ -4,7 +4,6 @@ namespace The3LabsTeam\AdsPostParser;
 
 use Illuminate\Support\Facades\Blade;
 use voku\helper\HtmlDomParser;
-use function DI\string;
 
 class AdsPostParser
 {
@@ -42,14 +41,15 @@ class AdsPostParser
 
             $currentElement = $item;
             $afterElement = $index < count($items) - 1 ? $items[$index + 1] : null;
-            $isBlackList = preg_match('/' . implode('|', $blacklist) . '/', $currentElement->outertext) || ($afterElement ? preg_match('/' . implode('|', $blacklist) . '/', $afterElement->outertext) : false);
+            $isBlackList = preg_match('/'.implode('|', $blacklist).'/', $currentElement->outertext) || ($afterElement ? preg_match('/'.implode('|', $blacklist).'/', $afterElement->outertext) : false);
             // === END BLACKLIST ===
 
             if (in_array($index, $thresholds)) {
                 if ($isBlackList) {
-                    $thresholds = array_map(function($value) {
+                    $thresholds = array_map(function ($value) {
                         return $value + 1;
                     }, $thresholds);
+
                     continue;
                 }
 
@@ -79,7 +79,6 @@ class AdsPostParser
         return $this->dom->save();
     }
 
-
     /**
      * Append a single advertising
      */
@@ -95,12 +94,11 @@ class AdsPostParser
         $beforeItem = $items[$index];
         $nextItem = $index < $maxLoop - 1 ? $items[$index + 1] : null;
 
-
         if (
             ! preg_match($this->blacklistBefore, $beforeItem->outertext) && ($nextItem === null || ! preg_match($this->blacklistAfter, $nextItem->outertext))
         ) {
             try {
-                echo $index . ' - ' . $advIndex . '<br>';
+                echo $index.' - '.$advIndex.'<br>';
                 $beforeItem->outertext .= Blade::render('ads-post-parser::ads'.$advIndex);
             } catch (\Exception $e) {
                 // Content without ADV


### PR DESCRIPTION
Le differenze principali tra `appendAdvertising()` e `oldappendAdvertising()` sono:

1. **Logica di iterazione**:
   - `appendAdvertising()`: Itera attraverso tutti gli elementi del DOM e verifica se l'indice corrente è presente nei `thresholds`. Se sì, tenta di aggiungere la pubblicità.
   - `oldappendAdvertising()`: Itera attraverso i `thresholds` e chiama `appendSingleAdvertising()` per ogni soglia.

2. **Gestione della blacklist**:
   - `appendAdvertising()`: Verifica se l'elemento corrente o il successivo è nella blacklist e, in tal caso, incrementa i `thresholds` per evitare di inserire pubblicità in quegli elementi.
   - `oldappendAdvertising()`: Verifica la blacklist all'interno di `appendSingleAdvertising()` e, se l'elemento è nella blacklist, chiama ricorsivamente se stessa con l'indice incrementato.

3. **Aggiunta della pubblicità**:
   - `appendAdvertising()`: Aggiunge la pubblicità direttamente all'elemento corrente se l'indice è presente nei `thresholds` e non è nella blacklist.
   - `oldappendAdvertising()`: Aggiunge la pubblicità chiamando `appendSingleAdvertising()` che gestisce l'inserimento della pubblicità e la verifica della blacklist.

4. **Contatore delle pubblicità**:
   - `appendAdvertising()`: Utilizza un contatore `$adsCount` per tenere traccia del numero di pubblicità inserite.
   - `oldappendAdvertising()`: Utilizza l'indice di `thresholds` come contatore per le pubblicità.

In sintesi, `appendAdvertising()` è una versione più compatta e diretta che gestisce l'inserimento delle pubblicità e la verifica della blacklist in un unico ciclo, mentre `oldappendAdvertising()` delega parte della logica a `appendSingleAdvertising()`, risultando in un approccio più modulare ma potenzialmente meno efficiente.